### PR TITLE
Update create_ec2.sh

### DIFF
--- a/day03/create_ec2.sh
+++ b/day03/create_ec2.sh
@@ -4,8 +4,9 @@ set -euo pipefail
 check_awscli() {
     if ! command -v aws &> /dev/null; then
         echo "AWS CLI is not installed. Please install it first." >&2
-        exit 1
+        return 1
     fi
+    return 0
 }
 
 install_awscli() {


### PR DESCRIPTION
Because of exit 1, the script terminates immediately and install_awscli will never run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of missing AWS CLI by enabling automatic installation attempt when the tool is not detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->