### PR TITLE
Fix AWS CLI installation logic in check_awscli()

### DIFF
--- a/day03/create_ec2.sh
+++ b/day03/create_ec2.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 check_awscli() {
     if ! command -v aws &> /dev/null; then
         echo "AWS CLI is not installed. Please install it first." >&2
-        exit 1
+        return 1
     fi
 }
 


### PR DESCRIPTION
## Issue

The `check_awscli()` function used `exit 1` when AWS CLI was not installed.

Since the function is invoked as:

```bash
check_awscli || install_awscli
```

calling `exit 1` terminates the entire script before `install_awscli()` can be executed.

## Fix

Replaced:

```bash
exit 1
```

with:

```bash
return 1
```

This allows the function to return a failure status to the caller while preserving the intended control flow.

## Why not `return 0`?

In shell scripting, a return value of `0` indicates success.

If `check_awscli()` returns `0` when AWS CLI is not installed, the shell interprets the check as successful and the right-hand side of:

```bash
check_awscli || install_awscli
```

will never execute.

Returning `1` correctly indicates failure and triggers `install_awscli()` through the `||` operator.

## Result

- AWS CLI installed: execution continues normally.
- AWS CLI not installed: `install_awscli()` is executed.
- The script proceeds with the remaining workflow after installation.